### PR TITLE
Added a general text on the relationship with publishing

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
             <dd>Coordination on indexing representation of node descriptions.</dd>
 
             <dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></dt>
-            <dd><i class="todo">Ivan?</i></dd>
+            <dd>The Publishing Working Group is considering using JSON-LD as a serialization format for various types of metadata for Web Publications, as well as a serialization format for the Web Publication Manifest. These applications may raise new issues related in terms of usability.</dd>
 
             <dt><a href="https://www.w3.org/2017/vc/WG/">Verifiable Claims Working Group</a></dt>
             <dd>Coordination on named graph indexing and support for <a href="https://json-ld.github.io/normalization/spec/">RDF Dataset Normalization</a> and <a href="https://w3c-dvcg.github.io/ld-signatures/">Linked Data Signatures</a>.</dd>


### PR DESCRIPTION
The text is non-committal, because the Publ WG has not yet made a decision on using JSON-LD. (This may happen by the time this charter goes to formal vote, in which case this can be changed at that point.)